### PR TITLE
Customise barcode size

### DIFF
--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -11,9 +11,13 @@ class Barcode {
     protected $validator;
     protected $parser;
 
-    public function __construct()
+    public function __construct(Html $html = null)
     {
-        $this->html = new Html;
+        if($html === null) {
+            $this->html = new Html;
+        } else {
+            $this->html = $html;
+        }
         $this->validator = new Validator;
         $this->parser = new Parser;
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -9,10 +9,18 @@ class Html {
     const WHITE_LARGE = 'W';
     const WHITE_THIN  = 'w';
 
-    public function __construct($barcode_height = 50, $thin_line_width = 1)
+    /**
+     * @param array $options Allow default CSS values to be modified
+     */
+    public function __construct($options = [])
     {
-        $large_line_width = $thin_line_width * 3;
-        $this->cssStyle = '.barcode{height:'.$barcode_height.'px}.barcode div{display:inline-block;height:100%}.barcode .black{border-color:#000;border-left-style:solid;width:0}.barcode .white{background:#fff}.barcode .thin.black{border-left-width:'.$thin_line_width.'px}.barcode .large.black{border-left-width:'.$large_line_width.'px}.barcode .thin.white{width:'.$thin_line_width.'px}.barcode .large.white{width:'.$large_line_width.'px}';
+        $defaults = [
+            'height' => 50,
+            'thin_lin_width' => 1
+        ];
+        $options += $defaults;
+        $options['large_line_width'] = $options['thin_line_width'] * 3;
+        $this->cssStyle = '.barcode{height:'.$options['height'].'px}.barcode div{display:inline-block;height:100%}.barcode .black{border-color:#000;border-left-style:solid;width:0}.barcode .white{background:#fff}.barcode .thin.black{border-left-width:'.$options['thin_line_width'].'px}.barcode .large.black{border-left-width:'.$options['large_line_width'].'px}.barcode .thin.white{width:'.$options['thin_line_width'].'px}.barcode .large.white{width:'.$options['large_line_width'].'px}';
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -16,7 +16,7 @@ class Html {
     {
         $defaults = [
             'height' => 50,
-            'thin_lin_width' => 1
+            'thin_line_width' => 1
         ];
         $options += $defaults;
         $options['large_line_width'] = $options['thin_line_width'] * 3;

--- a/src/Html.php
+++ b/src/Html.php
@@ -9,9 +9,10 @@ class Html {
     const WHITE_LARGE = 'W';
     const WHITE_THIN  = 'w';
 
-    public function __construct()
+    public function __construct($barcode_height = 50, $thin_line_width = 1)
     {
-        $this->cssStyle = ".barcode{height:50px}.barcode div{display:inline-block;height:100%}.barcode .black{border-color:#000;border-left-style:solid;width:0}.barcode .white{background:#fff}.barcode .thin.black{border-left-width:1px}.barcode .large.black{border-left-width:3px}.barcode .thin.white{width:1px}.barcode .large.white{width:3px}";
+        $large_line_width = $thin_line_width * 3;
+        $this->cssStyle = '.barcode{height:'.$barcode_height.'px}.barcode div{display:inline-block;height:100%}.barcode .black{border-color:#000;border-left-style:solid;width:0}.barcode .white{background:#fff}.barcode .thin.black{border-left-width:'.$thin_line_width.'px}.barcode .large.black{border-left-width:'.$large_line_width.'px}.barcode .thin.white{width:'.$thin_line_width.'px}.barcode .large.white{width:'.$large_line_width.'px}';
     }
 
     /**


### PR DESCRIPTION
Great PHP script. We needed to customise it to have different barcode sizes and therefore added the ability to inject the Html class into the Barcode constructor with some options.

We are using this as follows to create a barcode with 100px height and 3px thin lines (so the large lines will automatically be 9px):

```php
$html = new Html([
            'height' => 100,
            'thin_line_width' => 3
        ]);
$barcode = new Barcode($html);
$barcode_css = $barcode->getCssStyle();
```
